### PR TITLE
Week number calculation bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13706,6 +13706,22 @@
         "node": ">=10"
       }
     },
+    "node_modules/ng-packagr/node_modules/rollup": {
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+      "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+      "dev": true,
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=14.18.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/ng-packagr/node_modules/rxjs": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.6.0.tgz",
@@ -16375,16 +16391,16 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.6.0.tgz",
-      "integrity": "sha512-qCgiBeSu2/AIOKWGFMiRkjPlGlcVwxAjwpGKQZOQYng+83Hip4PjrWHm7EQX1wnrvRqfTytEihRRfLHdX+hR4g==",
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
       "engines": {
-        "node": ">=14.18.0",
-        "npm": ">=8.0.0"
+        "node": ">=10.0.0"
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
@@ -29202,6 +29218,15 @@
             "brace-expansion": "^2.0.1"
           }
         },
+        "rollup": {
+          "version": "3.29.4",
+          "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.29.4.tgz",
+          "integrity": "sha512-oWzmBZwvYrU0iJHtDmhsm662rC15FRXmcjCk1xD771dFDx5jJ02ufAQQTn0etB2emNk4J9EZg/yWKpsn9BWGRw==",
+          "dev": true,
+          "requires": {
+            "fsevents": "~2.3.2"
+          }
+        },
         "rxjs": {
           "version": "7.6.0",
           "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.6.0.tgz",
@@ -31215,10 +31240,11 @@
       }
     },
     "rollup": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.6.0.tgz",
-      "integrity": "sha512-qCgiBeSu2/AIOKWGFMiRkjPlGlcVwxAjwpGKQZOQYng+83Hip4PjrWHm7EQX1wnrvRqfTytEihRRfLHdX+hR4g==",
+      "version": "2.79.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
+      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
       "dev": true,
+      "peer": true,
       "requires": {
         "fsevents": "~2.3.2"
       }

--- a/projects/angular-year-calendar/src/lib/pipes/week-number/week-number.pipe.ts
+++ b/projects/angular-year-calendar/src/lib/pipes/week-number/week-number.pipe.ts
@@ -58,7 +58,7 @@ export class WeekNumberPipe implements PipeTransform {
 
     // find out the distance from the first week's first day
     const roundFigure = ((currentWeekStartDate.getTime() - firstWeekFirstDate.getTime()) / 86400000);
-    result = (roundFigure % 7 === 0) ? roundFigure / 7 : 1 + Math.round(roundFigure / 7);
+    result = (roundFigure % 7 === 0) ? roundFigure / 7 + 1 : 1 + Math.round(roundFigure / 7);
     if (result <= 0) {
       result = weeksInYear + result;
     }


### PR DESCRIPTION
**Week number calculation issue**
 If the year start day is the same as the selected week start day, (roudingFigure is 0)
 by logic, it's divided by 7, But it's the 1st week of the current year.
 
_Before:_
![before](https://github.com/IOMechs/angular-year-calendar/assets/52977042/851c3cd6-943c-4a2a-a50f-093ffed82f2f)

_After:_
![after](https://github.com/IOMechs/angular-year-calendar/assets/52977042/51ce45ae-709f-4ec3-84c9-edfbab3f6898)
